### PR TITLE
Use existing parse & validate on ES assets

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/cache.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/cache.ts
@@ -39,6 +39,7 @@ export const getPackageInfo = (args: SharedKey) => {
 export const getArchivePackage = (args: SharedKey) => {
   const packageInfo = getPackageInfo(args);
   const paths = getArchiveFilelist(args);
+  if (!paths || !packageInfo) return undefined;
   return {
     paths,
     packageInfo,

--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -169,7 +169,6 @@ export const getEsPackage = async (
     filter: `${ASSETS_SAVED_OBJECT_TYPE}.attributes.package_name:${pkgName} AND ${ASSETS_SAVED_OBJECT_TYPE}.attributes.package_version:${pkgVersion} AND ${ASSETS_SAVED_OBJECT_TYPE}.attributes.asset_path:${manifestPath}`,
   });
   const packageInfo = yaml.load(soResManifest.saved_objects[0].attributes.data_utf8);
-
   const readmePath = `${pkgName}-${pkgVersion}/docs/README.md`;
   const readmeRes = await savedObjectsClient.find<PackageAsset>({
     type: ASSETS_SAVED_OBJECT_TYPE,

--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -23,7 +23,7 @@ import {
   RegistryDataStream,
 } from '../../../../common';
 import { getArchiveEntry } from './index';
-import { parseAndVerifyPolicyTemplates, parseAndVerifyStreams } from './validation';
+import { parseAndVerifyStreams } from './validation';
 import { pkgToPkgKey } from '../registry';
 
 // could be anything, picked this from https://github.com/elastic/elastic-agent-client/issues/17
@@ -226,7 +226,7 @@ export const getEsPackage = async (
       });
     })
   );
-  packageInfo.policy_templates = parseAndVerifyPolicyTemplates(packageInfo);
+  // packageInfo.policy_templates = parseAndVerifyPolicyTemplates(packageInfo);
   packageInfo.data_streams = dataStreams;
   return {
     paths,

--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -151,11 +151,16 @@ export async function getAsset(opts: {
 export const getEsPackage = async (
   pkgName: string,
   pkgVersion: string,
-  packageAssets: SavedObjectsBulkGetObject[],
+  packageAssets: PackageAssetReference[],
   savedObjectsClient: SavedObjectsClientContract
 ) => {
   const pkgKey = pkgToPkgKey({ name: pkgName, version: pkgVersion });
-  const soRes = await savedObjectsClient.bulkGet<PackageAsset>(packageAssets);
+  const bulkBody: SavedObjectsBulkGetObject[] = packageAssets.map((ref) => ({
+    id: ref.id,
+    type: ref.type,
+    fields: ['asset_path'],
+  }));
+  const soRes = await savedObjectsClient.bulkGet<PackageAsset>(bulkBody);
   const paths = soRes.saved_objects.map((asset) => asset.attributes.asset_path);
 
   // create the packageInfo

--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -5,8 +5,8 @@
  */
 
 import { extname } from 'path';
-import yaml from 'js-yaml';
 import { uniq } from 'lodash';
+import yaml from 'js-yaml';
 import { isBinaryFile } from 'isbinaryfile';
 import mime from 'mime-types';
 import uuidv5 from 'uuid/v5';
@@ -23,8 +23,8 @@ import {
   RegistryDataStream,
 } from '../../../../common';
 import { getArchiveEntry } from './index';
-import { pkgToPkgKey } from '../registry';
 import { parseAndVerifyPolicyTemplates, parseAndVerifyStreams } from './validation';
+import { pkgToPkgKey } from '../registry';
 
 // could be anything, picked this from https://github.com/elastic/elastic-agent-client/issues/17
 const MAX_ES_ASSET_BYTES = 4 * 1024 * 1024;
@@ -169,6 +169,7 @@ export const getEsPackage = async (
     filter: `${ASSETS_SAVED_OBJECT_TYPE}.attributes.package_name:${pkgName} AND ${ASSETS_SAVED_OBJECT_TYPE}.attributes.package_version:${pkgVersion} AND ${ASSETS_SAVED_OBJECT_TYPE}.attributes.asset_path:${manifestPath}`,
   });
   const packageInfo = yaml.load(soResManifest.saved_objects[0].attributes.data_utf8);
+
   const readmePath = `${pkgName}-${pkgVersion}/docs/README.md`;
   const readmeRes = await savedObjectsClient.find<PackageAsset>({
     type: ASSETS_SAVED_OBJECT_TYPE,

--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -16,7 +16,7 @@ import {
   PackageAssetReference,
 } from '../../../../common';
 import { ArchiveEntry, getArchiveEntry, setArchiveEntry } from './index';
-import { preloadManifests, parseAndVerifyArchive } from './validation';
+import { parseAndVerifyEntries } from './validation';
 
 // could be anything, picked this from https://github.com/elastic/elastic-agent-client/issues/17
 const MAX_ES_ASSET_BYTES = 4 * 1024 * 1024;
@@ -166,20 +166,13 @@ export async function getEsPackage(opts: {
   const { references, savedObjectsClient } = opts;
   const assets = await getAssetsFromReferences({ references, savedObjectsClient });
   const entries: ArchiveEntry[] = assets.map(packageAssetToArchiveEntry);
+  const packageResponse = parseAndVerifyEntries(entries);
 
-  const paths: string[] = [];
   entries.forEach(({ path, buffer }) => {
     if (path && buffer) {
       setArchiveEntry(path, buffer);
-      paths.push(path);
     }
   });
 
-  preloadManifests(entries);
-  const packageInfo = parseAndVerifyArchive(paths);
-
-  return {
-    packageInfo,
-    paths,
-  };
+  return packageResponse;
 }

--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -23,7 +23,7 @@ import {
   RegistryDataStream,
 } from '../../../../common';
 import { getArchiveEntry } from './index';
-import { parseAndVerifyStreams } from './validation';
+import { parseAndVerifyPolicyTemplates, parseAndVerifyStreams } from './validation';
 import { pkgToPkgKey } from '../registry';
 
 // could be anything, picked this from https://github.com/elastic/elastic-agent-client/issues/17
@@ -226,7 +226,7 @@ export const getEsPackage = async (
       });
     })
   );
-  // packageInfo.policy_templates = parseAndVerifyPolicyTemplates(packageInfo);
+  packageInfo.policy_templates = parseAndVerifyPolicyTemplates(packageInfo);
   packageInfo.data_streams = dataStreams;
   return {
     paths,

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -69,6 +69,10 @@ export async function parseAndVerifyArchiveBuffer(
   contentType: string
 ): Promise<{ paths: string[]; packageInfo: ArchivePackage }> {
   const entries = await unpackBufferEntries(archiveBuffer, contentType);
+  return parseAndVerifyEntries(entries);
+}
+
+export function parseAndVerifyEntries(entries: ArchiveEntry[]) {
   preloadManifests(entries);
 
   const paths: string[] = entries.map(({ path }) => path);
@@ -78,13 +82,13 @@ export async function parseAndVerifyArchiveBuffer(
   };
 }
 
-export function preloadManifests(entries: ArchiveEntry[]) {
+function preloadManifests(entries: ArchiveEntry[]) {
   entries.forEach(({ path, buffer }) => {
     if (path.endsWith(MANIFEST_NAME) && buffer) MANIFESTS[path] = buffer;
   });
 }
 
-export function parseAndVerifyArchive(paths: string[]): ArchivePackage {
+function parseAndVerifyArchive(paths: string[]): ArchivePackage {
   // The top-level directory must match pkgName-pkgVersion, and no other top-level files or directories may be present
   const toplevelDir = paths[0].split('/')[0];
   paths.forEach((path) => {

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -168,7 +168,7 @@ function parseAndVerifyReadme(paths: string[], pkgName: string, pkgVersion: stri
   return paths.includes(readmePath) ? `/package/${pkgName}/${pkgVersion}${readmeRelPath}` : null;
 }
 
-export function parseAndVerifyDataStreams(
+function parseAndVerifyDataStreams(
   paths: string[],
   pkgName: string,
   pkgVersion: string
@@ -237,7 +237,7 @@ export function parseAndVerifyDataStreams(
   return dataStreams;
 }
 
-export function parseAndVerifyStreams(manifest: any, dataStreamPath: string): RegistryStream[] {
+function parseAndVerifyStreams(manifest: any, dataStreamPath: string): RegistryStream[] {
   const streams: RegistryStream[] = [];
   const manifestStreams = manifest.streams;
   if (manifestStreams && manifestStreams.length > 0) {
@@ -269,7 +269,7 @@ export function parseAndVerifyStreams(manifest: any, dataStreamPath: string): Re
   }
   return streams;
 }
-export function parseAndVerifyVars(manifestVars: any[], location: string): RegistryVarsEntry[] {
+function parseAndVerifyVars(manifestVars: any[], location: string): RegistryVarsEntry[] {
   const vars: RegistryVarsEntry[] = [];
   if (manifestVars && manifestVars.length > 0) {
     manifestVars.forEach((manifestVar) => {
@@ -304,9 +304,7 @@ export function parseAndVerifyVars(manifestVars: any[], location: string): Regis
   }
   return vars;
 }
-export function parseAndVerifyPolicyTemplates(
-  manifest: PackageSpecManifest
-): RegistryPolicyTemplate[] {
+function parseAndVerifyPolicyTemplates(manifest: PackageSpecManifest): RegistryPolicyTemplate[] {
   const policyTemplates: RegistryPolicyTemplate[] = [];
   const manifestPolicyTemplates = manifest.policy_templates;
   if (manifestPolicyTemplates && manifestPolicyTemplates.length > 0) {
@@ -337,7 +335,7 @@ export function parseAndVerifyPolicyTemplates(
   }
   return policyTemplates;
 }
-export function parseAndVerifyInputs(manifestInputs: any, location: string): RegistryInput[] {
+function parseAndVerifyInputs(manifestInputs: any, location: string): RegistryInput[] {
   const inputs: RegistryInput[] = [];
   if (manifestInputs && manifestInputs.length > 0) {
     manifestInputs.forEach((input: any) => {

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -16,7 +16,7 @@ import {
   PackageSpecManifest,
 } from '../../../../common/types';
 import { PackageInvalidArchiveError } from '../../../errors';
-import { unpackBufferEntries } from './index';
+import { ArchiveEntry, unpackBufferEntries } from './index';
 import { pkgToPkgKey } from '../registry';
 
 const MANIFESTS: Record<string, Buffer> = {};
@@ -69,19 +69,22 @@ export async function parseAndVerifyArchiveBuffer(
   contentType: string
 ): Promise<{ paths: string[]; packageInfo: ArchivePackage }> {
   const entries = await unpackBufferEntries(archiveBuffer, contentType);
-  const paths: string[] = [];
-  entries.forEach(({ path, buffer }) => {
-    paths.push(path);
-    if (path.endsWith(MANIFEST_NAME) && buffer) MANIFESTS[path] = buffer;
-  });
+  preloadManifests(entries);
 
+  const paths: string[] = entries.map(({ path }) => path);
   return {
     packageInfo: parseAndVerifyArchive(paths),
     paths,
   };
 }
 
-function parseAndVerifyArchive(paths: string[]): ArchivePackage {
+export function preloadManifests(entries: ArchiveEntry[]) {
+  entries.forEach(({ path, buffer }) => {
+    if (path.endsWith(MANIFEST_NAME) && buffer) MANIFESTS[path] = buffer;
+  });
+}
+
+export function parseAndVerifyArchive(paths: string[]): ArchivePackage {
   // The top-level directory must match pkgName-pkgVersion, and no other top-level files or directories may be present
   const toplevelDir = paths[0].split('/')[0];
   paths.forEach((path) => {
@@ -97,29 +100,9 @@ function parseAndVerifyArchive(paths: string[]): ArchivePackage {
     throw new PackageInvalidArchiveError(`Package must contain a top-level ${MANIFEST_NAME} file.`);
   }
 
-  // ... which must be valid YAML
-  let manifest: ArchivePackage;
-  try {
-    manifest = yaml.load(manifestBuffer.toString());
-  } catch (error) {
-    throw new PackageInvalidArchiveError(`Could not parse top-level package manifest: ${error}.`);
-  }
-
-  // must have mandatory fields
-  const reqGiven = pick(manifest, requiredArchivePackageProps);
-  const requiredKeysMatch =
-    Object.keys(reqGiven).toString() === requiredArchivePackageProps.toString();
-  if (!requiredKeysMatch) {
-    const list = requiredArchivePackageProps.join(', ');
-    throw new PackageInvalidArchiveError(
-      `Invalid top-level package manifest: one or more fields missing of ${list}`
-    );
-  }
-
-  // at least have all required properties
-  // get optional values and combine into one object for the remaining operations
-  const optGiven = pick(manifest, optionalArchivePackageProps);
-  const parsed: ArchivePackage = { ...reqGiven, ...optGiven };
+  // load & parse the file
+  const manifest = loadYamlManifest(manifestBuffer);
+  const parsed: ArchivePackage = parsePackageManifest(manifest);
 
   // Package name and version from the manifest must match those from the toplevel directory
   const pkgKey = pkgToPkgKey({ name: parsed.name, version: parsed.version });
@@ -129,9 +112,9 @@ function parseAndVerifyArchive(paths: string[]): ArchivePackage {
     );
   }
 
+  // Add any properties not present in the manifest
   parsed.data_streams = parseAndVerifyDataStreams(paths, parsed.name, parsed.version);
-  parsed.policy_templates = parseAndVerifyPolicyTemplates(manifest);
-  // add readme if exists
+  parsed.policy_templates = parseAndVerifyPolicyTemplates(parsed);
   const readme = parseAndVerifyReadme(paths, parsed.name, parsed.version);
   if (readme) {
     parsed.readme = readme;
@@ -139,11 +122,48 @@ function parseAndVerifyArchive(paths: string[]): ArchivePackage {
 
   return parsed;
 }
+
+// at least has all required properties
+// include any allowed optional properties
+// ignore unknown properties
+function parsePackageManifest(manifest: ArchivePackage) {
+  const reqGiven = manifestHasRequiredFields(manifest);
+  const optGiven = pick(manifest, optionalArchivePackageProps);
+  const parsed: ArchivePackage = { ...reqGiven, ...optGiven };
+
+  return parsed;
+}
+
+function manifestHasRequiredFields(manifest: ArchivePackage) {
+  const reqGiven = pick(manifest, requiredArchivePackageProps);
+  const requiredKeysMatch =
+    Object.keys(reqGiven).toString() === requiredArchivePackageProps.toString();
+  if (!requiredKeysMatch) {
+    const list = requiredArchivePackageProps.join(', ');
+    throw new PackageInvalidArchiveError(
+      `Invalid top-level package manifest: one or more fields missing of ${list}`
+    );
+  }
+  return reqGiven;
+}
+
+// is present & valid YAML
+function loadYamlManifest(given: Buffer | string): ArchivePackage {
+  let manifest;
+  try {
+    manifest = yaml.load(given.toString());
+  } catch (error) {
+    throw new PackageInvalidArchiveError(`Could not parse top-level package manifest: ${error}.`);
+  }
+  return manifest;
+}
+
 function parseAndVerifyReadme(paths: string[], pkgName: string, pkgVersion: string): string | null {
   const readmeRelPath = `/docs/README.md`;
   const readmePath = `${pkgName}-${pkgVersion}${readmeRelPath}`;
   return paths.includes(readmePath) ? `/package/${pkgName}/${pkgVersion}${readmeRelPath}` : null;
 }
+
 export function parseAndVerifyDataStreams(
   paths: string[],
   pkgName: string,
@@ -190,9 +210,9 @@ export function parseAndVerifyDataStreams(
       type,
       dataset,
     } = manifest;
-    if (!(dataStreamTitle && release && type)) {
+    if (!dataStreamTitle) {
       throw new PackageInvalidArchiveError(
-        `Invalid manifest for data stream '${dataStreamPath}': one or more fields missing of 'title', 'release', 'type'`
+        `Invalid manifest for data stream '${dataStreamPath}': one or more fields missing of 'title'`
       );
     }
     const streams = parseAndVerifyStreams(manifest, dataStreamPath);
@@ -212,6 +232,7 @@ export function parseAndVerifyDataStreams(
 
   return dataStreams;
 }
+
 export function parseAndVerifyStreams(manifest: any, dataStreamPath: string): RegistryStream[] {
   const streams: RegistryStream[] = [];
   const manifestStreams = manifest.streams;

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -287,13 +287,15 @@ export function parseAndVerifyPolicyTemplates(
   if (manifestPolicyTemplates && manifestPolicyTemplates.length > 0) {
     manifestPolicyTemplates.forEach((policyTemplate: any) => {
       const { name, title: policyTemplateTitle, description, inputs, multiple } = policyTemplate;
-      if (!(name && policyTemplateTitle && description && inputs)) {
+      if (!(name && policyTemplateTitle && description)) {
         throw new PackageInvalidArchiveError(
-          `Invalid top-level manifest: one of mandatory fields 'name', 'title', 'description', 'input' missing in policy template: ${policyTemplate}`
+          `Invalid top-level manifest: one of mandatory fields 'name', 'title', 'description' is missing in policy template: ${policyTemplate}`
         );
       }
-
-      const parsedInputs = parseAndVerifyInputs(inputs, `config template ${name}`);
+      let parsedInputs: RegistryInput[] | undefined = [];
+      if (inputs) {
+        parsedInputs = parseAndVerifyInputs(inputs, `config template ${name}`);
+      }
 
       // defaults to true if undefined, but may be explicitly set to false.
       let parsedMultiple = true;

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -13,6 +13,7 @@ import {
   RegistryInput,
   RegistryStream,
   RegistryVarsEntry,
+  PackageSpecManifest,
 } from '../../../../common/types';
 import { PackageInvalidArchiveError } from '../../../errors';
 import { unpackBufferEntries } from './index';
@@ -143,7 +144,7 @@ function parseAndVerifyReadme(paths: string[], pkgName: string, pkgVersion: stri
   const readmePath = `${pkgName}-${pkgVersion}${readmeRelPath}`;
   return paths.includes(readmePath) ? `/package/${pkgName}/${pkgVersion}${readmeRelPath}` : null;
 }
-function parseAndVerifyDataStreams(
+export function parseAndVerifyDataStreams(
   paths: string[],
   pkgName: string,
   pkgVersion: string
@@ -243,7 +244,7 @@ export function parseAndVerifyStreams(manifest: any, dataStreamPath: string): Re
   }
   return streams;
 }
-function parseAndVerifyVars(manifestVars: any[], location: string): RegistryVarsEntry[] {
+export function parseAndVerifyVars(manifestVars: any[], location: string): RegistryVarsEntry[] {
   const vars: RegistryVarsEntry[] = [];
   if (manifestVars && manifestVars.length > 0) {
     manifestVars.forEach((manifestVar) => {
@@ -278,10 +279,12 @@ function parseAndVerifyVars(manifestVars: any[], location: string): RegistryVars
   }
   return vars;
 }
-export function parseAndVerifyPolicyTemplates(manifest: any): RegistryPolicyTemplate[] {
+export function parseAndVerifyPolicyTemplates(
+  manifest: PackageSpecManifest
+): RegistryPolicyTemplate[] {
   const policyTemplates: RegistryPolicyTemplate[] = [];
   const manifestPolicyTemplates = manifest.policy_templates;
-  if (manifestPolicyTemplates && manifestPolicyTemplates > 0) {
+  if (manifestPolicyTemplates && manifestPolicyTemplates.length > 0) {
     manifestPolicyTemplates.forEach((policyTemplate: any) => {
       const { name, title: policyTemplateTitle, description, inputs, multiple } = policyTemplate;
       if (!(name && policyTemplateTitle && description && inputs)) {
@@ -307,7 +310,7 @@ export function parseAndVerifyPolicyTemplates(manifest: any): RegistryPolicyTemp
   }
   return policyTemplates;
 }
-function parseAndVerifyInputs(manifestInputs: any, location: string): RegistryInput[] {
+export function parseAndVerifyInputs(manifestInputs: any, location: string): RegistryInput[] {
   const inputs: RegistryInput[] = [];
   if (manifestInputs && manifestInputs.length > 0) {
     manifestInputs.forEach((input: any) => {

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -211,7 +211,7 @@ function parseAndVerifyDataStreams(
 
   return dataStreams;
 }
-function parseAndVerifyStreams(manifest: any, dataStreamPath: string): RegistryStream[] {
+export function parseAndVerifyStreams(manifest: any, dataStreamPath: string): RegistryStream[] {
   const streams: RegistryStream[] = [];
   const manifestStreams = manifest.streams;
   if (manifestStreams && manifestStreams.length > 0) {
@@ -278,7 +278,7 @@ function parseAndVerifyVars(manifestVars: any[], location: string): RegistryVars
   }
   return vars;
 }
-function parseAndVerifyPolicyTemplates(manifest: any): RegistryPolicyTemplate[] {
+export function parseAndVerifyPolicyTemplates(manifest: any): RegistryPolicyTemplate[] {
   const policyTemplates: RegistryPolicyTemplate[] = [];
   const manifestPolicyTemplates = manifest.policy_templates;
   if (manifestPolicyTemplates && manifestPolicyTemplates > 0) {

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -113,6 +113,7 @@ export async function installIndexPatterns(
       pkgName: pkg.name,
       pkgVersion: pkg.version,
       pkgInstallSource: pkg.installSource,
+      savedObjectsClient,
     })
   );
   const packages = await Promise.all(packagesToFetchPromise);

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { SavedObject, SavedObjectsClientContract } from 'src/core/server';
+import { SavedObjectsClientContract } from 'src/core/server';
 import {
   INDEX_PATTERN_SAVED_OBJECT_TYPE,
   INDEX_PATTERN_PLACEHOLDER_SUFFIX,
@@ -14,11 +14,7 @@ import { dataTypes, installationStatuses } from '../../../../../common/constants
 import { ArchivePackage, Installation, InstallSource, ValueOf } from '../../../../../common/types';
 import { RegistryPackage, CallESAsCurrentUser, DataType } from '../../../../types';
 import { appContextService } from '../../../../services';
-import {
-  getInstallationObject,
-  getPackageFromSource,
-  getPackageSavedObjects,
-} from '../../packages/get';
+import { getInstallation, getPackageFromSource, getPackageSavedObjects } from '../../packages/get';
 
 interface FieldFormatMap {
   [key: string]: FieldFormatMapItem;
@@ -89,12 +85,12 @@ export async function installIndexPatterns(
   );
 
   const packagesToFetch = installedPackagesSavedObjects.reduce<
-    Array<{ name: string; version: string; installedPkgSO: SavedObject<Installation> | undefined }>
+    Array<{ name: string; version: string; installation: Installation | undefined }>
   >((acc, pkgSO) => {
     acc.push({
       name: pkgSO.attributes.name,
       version: pkgSO.attributes.version,
-      installedPkgSO: pkgSO,
+      installation: pkgSO.attributes,
     });
     return acc;
   }, []);
@@ -111,7 +107,7 @@ export async function installIndexPatterns(
       packagesToFetch.push({
         name: pkgName,
         version: pkgVersion,
-        installedPkgSO: await getInstallationObject({ savedObjectsClient, pkgName }),
+        installation: await getInstallation({ savedObjectsClient, pkgName }),
       });
     }
   }
@@ -120,7 +116,7 @@ export async function installIndexPatterns(
     getPackageFromSource({
       pkgName: pkg.name,
       pkgVersion: pkg.version,
-      installedPkgSO: pkg.installedPkgSO,
+      installation: pkg.installation,
       savedObjectsClient,
     })
   );

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { SavedObject, SavedObjectsClientContract, SavedObjectsFindOptions } from 'src/core/server';
+import { SavedObjectsClientContract, SavedObjectsFindOptions } from 'src/core/server';
 import { isPackageLimited, installationStatuses } from '../../../../common';
 import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../constants';
 import { ArchivePackage, RegistryPackage, EpmPackageAdditions } from '../../../../common/types';
@@ -100,7 +100,7 @@ export async function getPackageInfo(options: {
     pkgName,
     pkgVersion,
     savedObjectsClient,
-    installedPkgSO: savedObject,
+    installation: savedObject?.attributes,
   });
   const { paths, packageInfo } = getPackageRes;
 
@@ -126,15 +126,15 @@ type GetPackageResponse = PackageResponse | undefined;
 export async function getPackageFromSource(options: {
   pkgName: string;
   pkgVersion: string;
-  installedPkgSO?: SavedObject<Installation>;
+  installation?: Installation;
   savedObjectsClient: SavedObjectsClientContract;
 }): Promise<PackageResponse> {
-  const { pkgName, pkgVersion, installedPkgSO, savedObjectsClient } = options;
+  const { pkgName, pkgVersion, installation, savedObjectsClient } = options;
   let res: GetPackageResponse;
   // if the package is installed
 
-  if (installedPkgSO && installedPkgSO.attributes.version === pkgVersion) {
-    const { install_source: pkgInstallSource } = installedPkgSO.attributes;
+  if (installation && installation.version === pkgVersion) {
+    const { install_source: pkgInstallSource } = installation;
     // check cache
     res = getArchivePackage({
       name: pkgName,
@@ -145,7 +145,7 @@ export async function getPackageFromSource(options: {
       res = await getEsPackage(
         pkgName,
         pkgVersion,
-        installedPkgSO.attributes.package_assets,
+        installation.package_assets,
         savedObjectsClient
       );
     }

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -11,7 +11,7 @@ import { ArchivePackage, RegistryPackage, EpmPackageAdditions } from '../../../.
 import { Installation, PackageInfo, KibanaAssetType } from '../../../types';
 import * as Registry from '../registry';
 import { createInstallableFrom, isRequiredPackage } from './index';
-import { getEsPackage } from '../archive/save_to_es';
+import { getEsPackage } from '../archive/storage';
 import { getArchivePackage } from '../archive';
 
 export { getFile, SearchParams } from '../registry';

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -151,9 +151,15 @@ export async function getPackageFromSource(options: {
     if (!res) {
       res = await getEsPackage(pkgName, pkgVersion, savedObjectsClient);
     }
-    // for packages not in cache or package storage and installed from registry
+    // for packages not in cache or package storage and installed from registry, check registry
     if (!res && pkgInstallSource === 'registry') {
-      res = await Registry.getRegistryPackage(pkgName, pkgVersion);
+      try {
+        res = await Registry.getRegistryPackage(pkgName, pkgVersion);
+        // TODO: add to cache and storage here?
+      } catch (error) {
+        // treating this is a 404 as no status code returned
+        // in the unlikely event its missing from cache, storage, and never installed from registry
+      }
     }
   } else {
     // else package is not installed or installed and missing from cache and storage and installed from registry

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -142,12 +142,10 @@ export async function getPackageFromSource(options: {
     });
     // check storage
     if (!res) {
-      res = await getEsPackage(
-        pkgName,
-        pkgVersion,
-        installation.package_assets,
-        savedObjectsClient
-      );
+      res = await getEsPackage({
+        references: installation.package_assets,
+        savedObjectsClient,
+      });
     }
     // for packages not in cache or package storage and installed from registry, check registry
     if (!res && pkgInstallSource === 'registry') {

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -12,7 +12,7 @@ import { Installation, PackageInfo, KibanaAssetType } from '../../../types';
 import * as Registry from '../registry';
 import { createInstallableFrom, isRequiredPackage } from './index';
 import { getEsPackage } from '../archive/storage';
-import { getArchivePackage } from '../archive';
+import { getArchivePackage, setPackageInfo, setArchiveFilelist } from '../archive';
 
 export { getFile, SearchParams } from '../registry';
 
@@ -163,10 +163,16 @@ export async function getPackageFromSource(options: {
     // else package is not installed or installed and missing from cache and storage and installed from registry
     res = await Registry.getRegistryPackage(pkgName, pkgVersion);
   }
+
   if (!res) throw new Error(`package info for ${pkgName}-${pkgVersion} does not exist`);
+
+  const { paths, packageInfo } = res;
+  setArchiveFilelist({ name: pkgName, version: pkgVersion }, paths);
+  setPackageInfo({ name: pkgName, version: pkgVersion, packageInfo });
+
   return {
-    paths: res.paths,
-    packageInfo: res.packageInfo,
+    paths,
+    packageInfo,
   };
 }
 

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -148,7 +148,7 @@ export async function getInfo(name: string, version: string) {
 export async function getRegistryPackage(
   name: string,
   version: string
-): Promise<{ paths: string[]; packageInfo: RegistryPackage } | undefined> {
+): Promise<{ paths: string[]; packageInfo: RegistryPackage }> {
   const installSource = 'registry';
   let paths = getArchiveFilelist({ name, version });
   if (!paths || paths.length === 0) {
@@ -163,8 +163,6 @@ export async function getRegistryPackage(
   }
 
   const packageInfo = await getInfo(name, version);
-  if (!paths || !packageInfo) return undefined;
-
   return { paths, packageInfo };
 }
 

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -148,7 +148,7 @@ export async function getInfo(name: string, version: string) {
 export async function getRegistryPackage(
   name: string,
   version: string
-): Promise<{ paths: string[]; packageInfo: RegistryPackage }> {
+): Promise<{ paths: string[]; packageInfo: RegistryPackage } | undefined> {
   const installSource = 'registry';
   let paths = getArchiveFilelist({ name, version });
   if (!paths || paths.length === 0) {
@@ -163,6 +163,7 @@ export async function getRegistryPackage(
   }
 
   const packageInfo = await getInfo(name, version);
+  if (!paths || !packageInfo) return undefined;
 
   return { paths, packageInfo };
 }


### PR DESCRIPTION
## Summary

 * Exposed `parseAndVerifyEntries` from validation.ts
 * Updated `getEsPackage` be PackageAsset[] => ArchiveEntry[] => `parseAndVerifyEntries`
 * Factored `getAssetsFromReferences` & `packageAssetToArchiveEntry` out of `getEsPackage`
 * Made change replacing `installedPkgSO` with `installation`