### PR TITLE
Send `content` as single doc, no serialization

### DIFF
--- a/x-pack/platform/packages/shared/ai-infra/inference-common/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/index.ts
@@ -62,6 +62,7 @@ export {
   type ConnectorTelemetryMetadata,
   type AnonymizationRule,
   type RegexAnonymizationRule,
+  type NamedEntityRecognitionRule,
   type AnonymizationEntity,
   type Anonymization,
   type Deanonymization,

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/anonymization/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/anonymization/index.ts
@@ -14,4 +14,5 @@ export type {
   DeanonymizationOutput,
   DeanonymizedMessage,
   RegexAnonymizationRule,
+  NamedEntityRecognitionRule,
 } from './types';

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/index.ts
@@ -77,4 +77,5 @@ export type {
   DeanonymizationOutput,
   DeanonymizedMessage,
   RegexAnonymizationRule,
+  NamedEntityRecognitionRule,
 } from './anonymization';

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_messages.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_messages.ts
@@ -5,202 +5,21 @@
  * 2.0.
  */
 
-import {
-  AnonymizationRule,
-  AnonymizationEntity,
-  AnonymizationOutput,
-  RegexAnonymizationRule,
-  Anonymization,
-} from '@kbn/inference-common';
-import { withInferenceSpan } from '@kbn/inference-tracing';
-import { Message } from '@kbn/inference-common';
-import { chunk, merge, partition } from 'lodash';
-import objectHash from 'object-hash';
 import { ElasticsearchClient } from '@kbn/core/server';
-import type { Logger } from '@kbn/logging';
-import pLimit from 'p-limit';
-import { getAnonymizableMessageParts } from './get_anonymizable_message_parts';
-
-const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
-const DEFAULT_BATCH_SIZE = 1_000;
-const DEFAULT_CHUNK_SIZE = 1_000;
-
-export interface InferenceChunk {
-  chunkText: string;
-  charStartOffset: number;
-}
-
-export function chunkText(text: string, maxChars = DEFAULT_CHUNK_SIZE): InferenceChunk[] {
-  const chunks: InferenceChunk[] = [];
-  for (let i = 0; i < text.length; i += maxChars) {
-    chunks.push({
-      chunkText: text.slice(i, i + maxChars),
-      charStartOffset: i,
-    });
-  }
-  return chunks;
-}
-
-function getEntityMask(entity: { class_name: string; value: string }) {
-  const hash = objectHash({
-    value: entity.value,
-    class_name: entity.class_name,
-  });
-  return `${entity.class_name}_${hash}`;
-}
-
-export async function anonymize({
-  input,
-  anonymizationRules,
-  esClient,
-}: {
-  input: string;
-  anonymizationRules: AnonymizationRule[];
-  esClient: ElasticsearchClient;
-}): Promise<{ output: string; anonymizations: Anonymization[] }> {
-  const [regexRules, nerRules] = partition(
-    anonymizationRules,
-    (rule): rule is RegexAnonymizationRule => rule.type === 'RegExp'
-  );
-
-  const entities: Array<{ rule: RegexAnonymizationRule; entity: AnonymizationEntity }> = [];
-
-  let output = input;
-
-  regexRules.forEach((rule) => {
-    const regex = new RegExp(rule.pattern);
-
-    let match: RegExpMatchArray | null = null;
-    while ((match = regex.exec(output))) {
-      const value = match[0];
-
-      const mask = getEntityMask({
-        value,
-        class_name: rule.entityClass,
-      });
-
-      output = output.replace(match[0], mask);
-
-      entities.push({
-        entity: {
-          value,
-          class_name: rule.entityClass,
-          mask,
-        },
-        rule,
-      });
-    }
-  });
-
-  let index = 0;
-
-  const anonymizations: Anonymization[] = [];
-  entities.forEach(({ entity, rule }) => {
-    const start = output.indexOf(entity.mask, index);
-    index = start + entity.mask.length;
-    anonymizations.push({
-      entity,
-      rule: {
-        type: rule.type,
-      },
-    });
-  });
-
-  if (!nerRules.length) {
-    return {
-      output,
-      anonymizations,
-    };
-  }
-
-  // Maximum number of concurrent requests
-  const limiter = pLimit(DEFAULT_MAX_CONCURRENT_REQUESTS);
-
-  for (const nerRule of nerRules) {
-    let offset = 0;
-    // Chunk the text due to token limit of model
-    const chunks = chunkText(output);
-    // Limit chunks into batches per request
-    const batches = chunk(chunks, DEFAULT_BATCH_SIZE);
-
-    for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
-      const batchChunks = batches[batchIndex];
-
-      const results = await limiter(async () =>
-        withInferenceSpan('infer_ner', async () => {
-          let response;
-          try {
-            const docs = batchChunks.map((batchChunk) => ({ text_field: batchChunk.chunkText }));
-            response = await esClient.ml.inferTrainedModel({
-              model_id: nerRule.modelId,
-              docs,
-            });
-          } catch (error) {
-            throw new Error(`Inference failed for NER model '${nerRule.modelId}'`, {
-              cause: error,
-            });
-          }
-          return response?.inference_results || [];
-        })
-      );
-
-      // Process each chunk with its result
-      for (let i = 0; i < batchChunks.length; i++) {
-        const batchChunk = batchChunks[i];
-        const result = results[i];
-
-        if (!result || !result.entities) continue;
-
-        // Process each entity in this chunk
-        for (const entityMatch of result.entities) {
-          // Calculate the positions in the chunk
-          const from = batchChunk.charStartOffset + entityMatch.start_pos + offset;
-          const to = batchChunk.charStartOffset + entityMatch.end_pos + offset;
-
-          const before = output.slice(0, from);
-          const after = output.slice(to);
-
-          // get the original entity text to avoid normalization from the model
-          const entityText = output.slice(from, to);
-          // Create the entity object
-          const entity = {
-            class_name: entityMatch.class_name,
-            value: entityText,
-          };
-
-          const mask = getEntityMask(entity);
-
-          // Update offset based on length difference
-          offset += mask.length - (to - from);
-          anonymizations.push({
-            entity: {
-              ...entity,
-              mask,
-            },
-            rule: nerRule,
-          });
-          output = before + mask + after;
-        }
-      }
-    }
-  }
-
-  return {
-    output,
-    anonymizations,
-  };
-}
+import { AnonymizationOutput, AnonymizationRule, Message } from '@kbn/inference-common';
+import { merge } from 'lodash';
+import { anonymizeRecords } from './anonymize_records';
+import { messageFromAnonymizationRecords } from './message_from_anonymization_records';
+import { messageToAnonymizationRecords } from './message_to_anonymization_records';
 
 export async function anonymizeMessages({
   messages,
   anonymizationRules,
   esClient,
-  logger,
 }: {
   messages: Message[];
   anonymizationRules: AnonymizationRule[];
   esClient: ElasticsearchClient;
-  logger: Logger;
 }): Promise<AnonymizationOutput> {
   const rules = anonymizationRules.filter((rule) => rule.enabled);
   if (!rules.length) {
@@ -209,26 +28,23 @@ export async function anonymizeMessages({
       anonymizations: [],
     };
   }
-  const toAnonymize = messages.map(getAnonymizableMessageParts);
 
-  const { output, anonymizations } = await anonymize({
-    input: JSON.stringify(toAnonymize),
+  const toAnonymize = messages.map(messageToAnonymizationRecords);
+
+  const { records, anonymizations } = await anonymizeRecords({
+    input: toAnonymize,
     anonymizationRules: rules,
     esClient,
   });
-  try {
-    const anonymized = JSON.parse(output) as typeof toAnonymize;
 
-    const anonymizedMessages = messages.map((message, index) => {
-      return merge({}, message, anonymized[index]);
-    });
+  const anonymizedMessages = messages.map((original, index) => {
+    const map = records[index];
 
-    return {
-      messages: anonymizedMessages,
-      anonymizations,
-    };
-  } catch (error) {
-    logger.error('JSON.parse error trying to anonymize messages', error);
-    throw error;
-  }
+    return merge({}, original, messageFromAnonymizationRecords(map));
+  });
+
+  return {
+    messages: anonymizedMessages,
+    anonymizations,
+  };
 }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_records.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_records.test.ts
@@ -1,0 +1,256 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { anonymizeRecords } from './anonymize_records';
+import { AnonymizationRule } from '@kbn/inference-common';
+import { MlInferenceResponseResult } from '@elastic/elasticsearch/lib/api/types';
+
+const mockEsClient = {
+  ml: {
+    inferTrainedModel: jest.fn(),
+  },
+} as any;
+
+const setupMockResponse = (entitiesPerDoc: MlInferenceResponseResult[]) => {
+  mockEsClient.ml.inferTrainedModel.mockResolvedValue({
+    inference_results: entitiesPerDoc,
+  });
+};
+
+describe('anonymizeRecords', () => {
+  const nerRule: AnonymizationRule = {
+    type: 'NER',
+    enabled: true,
+    modelId: 'model-1',
+  };
+  const nerRule2: AnonymizationRule = {
+    type: 'NER',
+    enabled: true,
+    modelId: 'model-2',
+  };
+  const regexRule: AnonymizationRule = {
+    type: 'RegExp',
+    enabled: true,
+    entityClass: 'EMAIL',
+    pattern: '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}',
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('masks values using regex rule', async () => {
+    const input = [{ email: 'jorge21@gmail.com' }];
+
+    const { records, anonymizations } = await anonymizeRecords({
+      input,
+      anonymizationRules: [regexRule],
+      esClient: mockEsClient,
+    });
+
+    expect(records[0].email).not.toContain('jorge21@gmail.com');
+    expect(anonymizations.length).toBe(1);
+  });
+
+  it('calls inferTrainedModel with a SINGLE doc when content < MAX_TOKENS_PER_DOC', async () => {
+    const shortText = 'a'.repeat(500); // < 1000 chars
+    setupMockResponse([{ entities: [] } as any]);
+
+    await anonymizeRecords({
+      input: [{ content: shortText }],
+      anonymizationRules: [nerRule],
+      esClient: mockEsClient,
+    });
+
+    expect(mockEsClient.ml.inferTrainedModel).toHaveBeenCalledTimes(1);
+    const firstCallArgs = mockEsClient.ml.inferTrainedModel.mock.calls[0][0];
+    expect(firstCallArgs.docs).toHaveLength(1);
+    expect(firstCallArgs.docs[0].text_field).toBe(shortText);
+  });
+
+  it('splits text > MAX_TOKENS_PER_DOC into multiple docs', async () => {
+    const longText = 'b'.repeat(1500); // > 1000 chars => should be split into 2 docs (1000 + 500)
+
+    setupMockResponse(Array(2).fill({ entities: [] } as any));
+
+    await anonymizeRecords({
+      input: [{ content: longText }],
+      anonymizationRules: [nerRule],
+      esClient: mockEsClient,
+    });
+
+    expect(mockEsClient.ml.inferTrainedModel).toHaveBeenCalledTimes(1);
+    const callArgs = mockEsClient.ml.inferTrainedModel.mock.calls[0][0];
+    expect(callArgs.docs).toHaveLength(2);
+    expect(callArgs.docs[0].text_field).toBe(longText.slice(0, 1000));
+    expect(callArgs.docs[1].text_field).toBe(longText.slice(1000));
+  });
+
+  it('supports additional NER models of same class without duplication', async () => {
+    const input = [{ content: 'Bob and Alice are friends.' }];
+
+    // First model detects Alice only
+    mockEsClient.ml.inferTrainedModel.mockResolvedValueOnce({
+      inference_results: [
+        {
+          entities: [
+            {
+              entity: 'Alice',
+              class_name: 'PER',
+              class_probability: 0.99,
+              start_pos: 8,
+              end_pos: 13,
+            },
+          ],
+        },
+      ],
+    });
+
+    // Second model detects Bob only
+    mockEsClient.ml.inferTrainedModel.mockResolvedValueOnce({
+      inference_results: [
+        {
+          entities: [
+            {
+              entity: 'Bob',
+              class_name: 'PER',
+              class_probability: 0.97,
+              start_pos: 0,
+              end_pos: 3,
+            },
+          ],
+        },
+      ],
+    });
+
+    const { records, anonymizations } = await anonymizeRecords({
+      input,
+      anonymizationRules: [nerRule, nerRule2],
+      esClient: mockEsClient,
+    });
+
+    const outputStr = JSON.stringify(records);
+    expect(outputStr).not.toContain('Alice');
+    expect(outputStr).not.toContain('Bob');
+
+    const names = anonymizations.map((a) => a.entity.value).sort();
+    expect(names).toEqual(['Alice', 'Bob']);
+    expect(mockEsClient.ml.inferTrainedModel).toHaveBeenCalledTimes(2);
+  });
+
+  it('should anonymize records using a regex rule', async () => {
+    const input = [
+      {
+        email: 'jorge21@gmail.com',
+      },
+    ];
+
+    const result = await anonymizeRecords({
+      input,
+      anonymizationRules: [regexRule],
+      esClient: mockEsClient,
+    });
+
+    expect(result.records[0].email).not.toContain('jorge21@gmail.com');
+    expect(result.anonymizations.length).toBe(1);
+    expect(result.anonymizations[0].entity.value).toBe('jorge21@gmail.com');
+  });
+
+  it('should anonymize records using a NER rule', async () => {
+    const input = [
+      {
+        content: 'My name is Alice.',
+      },
+    ];
+
+    const content = input[0].content;
+
+    setupMockResponse([
+      {
+        entities: [
+          {
+            entity: 'Alice',
+            class_name: 'PER',
+            class_probability: 0.99,
+            start_pos: content.indexOf('Alice'),
+            end_pos: content.indexOf('Alice') + 'Alice'.length,
+          },
+        ],
+      } as any,
+    ]);
+
+    const result = await anonymizeRecords({
+      input,
+      anonymizationRules: [nerRule],
+      esClient: mockEsClient,
+    });
+
+    expect(result.records[0].content).not.toContain('Alice');
+    expect(result.anonymizations.length).toBe(1);
+    expect(result.anonymizations[0].entity.value).toBe('Alice');
+  });
+
+  it('allows subsequent NER models to add additional entities of the same class', async () => {
+    const input = [
+      {
+        content: 'Bob and Alice are friends.',
+      },
+    ];
+
+    // First NER model only detects "Alice"
+    mockEsClient.ml.inferTrainedModel.mockResolvedValueOnce({
+      inference_results: [
+        {
+          entities: [
+            {
+              entity: 'Alice',
+              class_name: 'PER',
+              class_probability: 0.99,
+              start_pos: 8,
+              end_pos: 13,
+            },
+          ],
+        },
+      ],
+    });
+
+    // Second NER model (same class) detects an additional entity, "Bob"
+    mockEsClient.ml.inferTrainedModel.mockResolvedValueOnce({
+      inference_results: [
+        {
+          entities: [
+            {
+              entity: 'Bob',
+              class_name: 'PER',
+              class_probability: 0.97,
+              start_pos: 0,
+              end_pos: 3,
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await anonymizeRecords({
+      input,
+      anonymizationRules: [nerRule, nerRule2],
+      esClient: mockEsClient,
+    });
+
+    // Ensure that neither original name remains in the output
+    expect(JSON.stringify(result.records)).not.toContain('Alice');
+    expect(JSON.stringify(result.records)).not.toContain('Bob');
+
+    // Ensure both entities are recorded in the anonymizations array
+    expect(result.anonymizations.length).toBe(2);
+    const names = result.anonymizations.map((a) => a.entity.value).sort();
+    expect(names).toEqual(['Alice', 'Bob']);
+
+    // Both models should have been invoked exactly once
+    expect(mockEsClient.ml.inferTrainedModel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_records.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_records.test.ts
@@ -77,7 +77,7 @@ describe('anonymizeRecords', () => {
 
     setupMockResponse(Array(2).fill({ entities: [] } as any));
 
-    await anonymizeRecords({
+    const { records } = await anonymizeRecords({
       input: [{ content: longText }],
       anonymizationRules: [nerRule],
       esClient: mockEsClient,
@@ -88,6 +88,10 @@ describe('anonymizeRecords', () => {
     expect(callArgs.docs).toHaveLength(2);
     expect(callArgs.docs[0].text_field).toBe(longText.slice(0, 1000));
     expect(callArgs.docs[1].text_field).toBe(longText.slice(1000));
+
+    // reconstructed value should match original and appear only once
+    expect(records[0].content).toBe(longText);
+    expect((records[0].content.match(/b/g) ?? []).length).toBe(1500);
   });
 
   it('supports additional NER models of same class without duplication', async () => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_records.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/anonymize_records.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient } from '@kbn/core/server';
+import { AnonymizationRule, RegexAnonymizationRule } from '@kbn/inference-common';
+import { partition } from 'lodash';
+import { AnonymizationState } from './types';
+import { executeRegexRule } from './execute_regex_rule';
+import { executeNerRule } from './execute_ner_rule';
+
+export async function anonymizeRecords<T extends Record<string, string | undefined>>({
+  input,
+  anonymizationRules,
+  esClient,
+}: {
+  input: T[];
+  anonymizationRules: AnonymizationRule[];
+  esClient: ElasticsearchClient;
+}): Promise<AnonymizationState>;
+
+export async function anonymizeRecords({
+  input,
+  anonymizationRules,
+  esClient,
+}: {
+  input: Array<Record<string, string>>;
+  anonymizationRules: AnonymizationRule[];
+  esClient: ElasticsearchClient;
+}): Promise<AnonymizationState> {
+  let state: AnonymizationState = {
+    records: input.concat(),
+    anonymizations: [],
+  };
+
+  const [regexRules, nerRules] = partition(
+    anonymizationRules,
+    (rule): rule is RegexAnonymizationRule => rule.type === 'RegExp'
+  );
+
+  for (const rule of regexRules) {
+    state = executeRegexRule({
+      rule,
+      state,
+    });
+  }
+
+  if (!nerRules.length) {
+    return state;
+  }
+
+  for (const nerRule of nerRules) {
+    state = await executeNerRule({
+      state,
+      rule: nerRule,
+      esClient,
+    });
+  }
+
+  return state;
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_ner_rule.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_ner_rule.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Anonymization, NamedEntityRecognitionRule } from '@kbn/inference-common';
+import { ElasticsearchClient } from '@kbn/core/server';
+import { chunk, mapValues } from 'lodash';
+import pLimit from 'p-limit';
+import { withInferenceSpan } from '@kbn/inference-tracing';
+import { AnonymizationState } from './types';
+import { getEntityMask } from './get_entity_mask';
+
+const MAX_TOKENS_PER_DOC = 1_000;
+
+function chunkText(text: string, maxChars = MAX_TOKENS_PER_DOC): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    chunks.push(text.slice(i, i + maxChars));
+  }
+  return chunks;
+}
+
+const DEFAULT_BATCH_SIZE = 1_000;
+const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
+
+/**
+ * Executes a NER anonymization rule, by:
+ *
+ * - For each record, iterate over the key-value pairs.
+ * - Split up each value in strings < MAX_TOKENS_PER_DOC, to stay within token limits
+ * for NER tasks.
+ * - Push each part to an array of strings, track the position in the array, so we can
+ * reconstruct the records later.
+ * - Create a {text_field:string} document for each part, and run NER inference over
+ * these documents in batches.
+ * - After retrieving the results:
+ *  - Iterate over the _input_ and find the inferred results by key + position
+ *  - For each detected entity, replace with a mask
+ *  - Append the original value & masked value to `state.anonymizations`
+ *  - Return the text with the masked values
+ *  - Reconstruct the original record
+ */
+export async function executeNerRule({
+  state,
+  rule,
+  esClient,
+}: {
+  state: AnonymizationState;
+  rule: NamedEntityRecognitionRule;
+  esClient: ElasticsearchClient;
+}): Promise<AnonymizationState> {
+  const anonymizations: Anonymization[] = state.anonymizations.concat();
+
+  const limiter = pLimit(DEFAULT_MAX_CONCURRENT_REQUESTS);
+
+  const allTexts: string[] = [];
+  const allPositions: Array<Record<string, number[]>> = [];
+
+  state.records.forEach((record) => {
+    const positionsForRecord: Record<string, number[]> = {};
+    allPositions.push(positionsForRecord);
+    Object.entries(record).forEach(([key, value]) => {
+      const positions: number[] = [];
+      positionsForRecord[key] = positions;
+      const texts = chunkText(value);
+      texts.forEach((text) => {
+        const idx = allTexts.length;
+        positions.push(idx);
+        allTexts.push(text);
+      });
+    });
+  });
+
+  const batched = chunk(allTexts, DEFAULT_BATCH_SIZE);
+
+  const results = (
+    await Promise.all(
+      batched.map(async (batch) => {
+        return await limiter(() =>
+          withInferenceSpan('infer_ner', async (span) => {
+            try {
+              const response = await esClient.ml.inferTrainedModel({
+                model_id: rule.modelId,
+                docs: batch.map((text) => ({ text_field: text })),
+              });
+
+              return response.inference_results;
+            } catch (error) {
+              throw new Error(`Inference failed for NER model '${rule.modelId}'`, {
+                cause: error,
+              });
+            }
+          })
+        );
+      })
+    )
+  ).flat();
+
+  const nextRecords = state.records.map((record, idx) => {
+    const nerInput = allPositions[idx];
+
+    return mapValues(record, (value, key) => {
+      const positions = nerInput[key];
+      return positions
+        .map((position) => {
+          const nerOutput = results[position];
+
+          let offset = 0;
+
+          let anonymizedValue = value!;
+
+          for (const entity of nerOutput.entities ?? []) {
+            const from = entity.start_pos + offset;
+            const to = entity.end_pos + offset;
+
+            const before = anonymizedValue.slice(0, from);
+            const after = anonymizedValue.slice(to);
+
+            const entityText = anonymizedValue.slice(from, to);
+
+            const mask = getEntityMask({ class_name: entity.class_name, value: entityText });
+
+            anonymizedValue = before + mask + after;
+            offset += mask.length - entityText.length;
+            anonymizations.push({
+              entity: { class_name: entity.class_name, value: entityText, mask },
+              rule,
+            });
+          }
+
+          return anonymizedValue;
+        })
+        .join('');
+    });
+  });
+
+  return {
+    records: nextRecords,
+    anonymizations,
+  };
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_ner_rule.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_ner_rule.ts
@@ -110,7 +110,7 @@ export async function executeNerRule({
 
           let offset = 0;
 
-          let anonymizedValue = value!;
+          let anonymizedValue = allTexts[position];
 
           for (const entity of nerOutput.entities ?? []) {
             const from = entity.start_pos + offset;

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_regex_rule.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/execute_regex_rule.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Anonymization, RegexAnonymizationRule } from '@kbn/inference-common';
+import { AnonymizationState } from './types';
+import { getEntityMask } from './get_entity_mask';
+
+/**
+ * Executes a regex anonymization rule, by iterating over the matches,
+ * and replacing each occurrence with a masked value.
+ */
+export function executeRegexRule({
+  state,
+  rule,
+}: {
+  state: AnonymizationState;
+  rule: RegexAnonymizationRule;
+}): AnonymizationState {
+  const regex = new RegExp(rule.pattern, 'g');
+
+  const anonymizations: Anonymization[] = state.anonymizations.concat();
+
+  const nextRecords = state.records.map((record) => {
+    const newRecord: Record<string, string> = {};
+    for (const [key, value] of Object.entries(record)) {
+      newRecord[key] = value.replace(regex, (match) => {
+        const mask = getEntityMask({ value: match, class_name: rule.entityClass });
+
+        anonymizations.push({
+          entity: { value: match, class_name: rule.entityClass, mask },
+          rule: { type: rule.type },
+        });
+
+        return mask;
+      });
+    }
+    return newRecord;
+  });
+
+  return { records: nextRecords, anonymizations };
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/get_anonymizable_message_parts.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/get_anonymizable_message_parts.ts
@@ -7,6 +7,13 @@
 
 import { Message, MessageRole } from '@kbn/inference-common';
 
+/**
+ * getAnonymizableMessageParts returns just the data of a
+ * message that needs to be anonymized. This prevents us
+ * from anonymizing things that should not be anonymized
+ * because of technical dependencies, like `role` or
+ * `toolCallId`.
+ */
 export function getAnonymizableMessageParts(message: Message) {
   if (message.role === MessageRole.Tool) {
     return {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/get_entity_mask.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/get_entity_mask.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import objectHash from 'object-hash';
+
+export function getEntityMask(entity: { class_name: string; value: string }) {
+  const hash = objectHash({
+    value: entity.value,
+    class_name: entity.class_name,
+  });
+  return `${entity.class_name}_${hash}`;
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_from_anonymization_records.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_from_anonymization_records.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Message, MessageContent } from '@kbn/inference-common';
+import { AnonymizationRecord } from './types';
+
+export function messageFromAnonymizationRecords(map: AnonymizationRecord): Message {
+  const anonymizableMessage = map;
+  const { content, contentParts, data } = anonymizableMessage;
+
+  return {
+    ...(content ? { content } : {}),
+    ...(contentParts ? { content: JSON.parse(contentParts) as MessageContent[] } : {}),
+    ...(data ? JSON.parse(data) : {}),
+  };
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_to_anonymization_records.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/message_to_anonymization_records.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Message } from '@kbn/inference-common';
+import { isEmpty } from 'lodash';
+import { getAnonymizableMessageParts } from './get_anonymizable_message_parts';
+import { AnonymizationRecord } from './types';
+
+export function messageToAnonymizationRecords(message: Message): AnonymizationRecord {
+  const anonymizableMessage = getAnonymizableMessageParts(message);
+  const { content, ...rest } = anonymizableMessage;
+
+  return {
+    ...(content && typeof content === 'string' ? { content } : {}),
+    ...(content && typeof content !== 'string' ? { contentParts: JSON.stringify(content) } : {}),
+    ...(!isEmpty(rest) ? { data: JSON.stringify(rest) } : {}),
+  };
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/types.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Anonymization } from '@kbn/inference-common';
+
+/**
+ * AnonymizationRecord are named strings that will be anonymized
+ * per key-value pair. This allows us to pass in plain text strings
+ * like `content` as a single document, instead of JSON.stringifying
+ * the entire message.
+ */
+export interface AnonymizationRecord {
+  // make sure it matches Record<string, string | undefined>
+  [x: string]: string | undefined;
+  data?: string;
+  contentParts?: string;
+  content?: string;
+}
+
+/**
+ * AnonymizationState is both the input and the output for executing
+ * an anonymization rule.
+ */
+export interface AnonymizationState {
+  records: Array<Record<string, string>>;
+  anonymizations: Anonymization[];
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
@@ -120,7 +120,6 @@ export function createChatCompleteCallbackApi({
               messages,
               anonymizationRules,
               esClient,
-              logger,
             })
           ).pipe(
             switchMap((anonymization) => {


### PR DESCRIPTION
Instead of serializing all messages and redacting them in a single pass, convert each message into an `AnonymizationRecord`. These are key-value pairs of which the value should be anonymized. Each value is processed separately. For regex rules, each regex is executed against each value. For NER rules, values are batched into a single NER request, and split up into more docs if they exceed the token limit.

Used o3 for writing tests for `anonymizeRecords` and `anonymizeMessages`.